### PR TITLE
Create vms.json

### DIFF
--- a/vms.json
+++ b/vms.json
@@ -1,0 +1,12 @@
+{
+  "name": "Mac OS X 10.4 (PPC64)",
+  "description": "Pre-installed legacy PowerPC macOS Tiger system, ready-to-run in UTM. Includes Apple Partition Table, boot loader, and minimal setup. Ideal for enthusiasts, retro computing, and classic Mac software exploration.",
+  "version": "10.4",
+  "architecture": "ppc64",
+  "os_type": "macos",
+  "unattended": false,
+  "image_link": "https://github.com/Hemant2000-karens/vm-downloads/releases/download/mac-os-x-10.4-ppc64/Mac.OS.X.10.4.PPC.utm.zip",
+  "author": "Hemant2000-karens",
+  "license": "Non-Redistributable Apple Software (Read Note)",
+  "note": "This VM is shared for educational and archival purposes only. Mac OS X is property of Apple Inc. Ensure you comply with applicable software licenses."
+}


### PR DESCRIPTION
### Mac OS X 10.4 PPC64 UTM VM

This is a preinstalled `.utm` virtual machine image of Mac OS X Tiger (10.4) for PowerPC 64-bit architecture, tested and exported from UTM 4.x on macOS.  

- Includes Apple Partition Table and bootloader
- Converted from `.sparsebundle` to `.img` to `.qcow2`
- For retro computing, PowerPC software testing and enthusiasts
- No cloud-init or unattended install support (OS limitation)

🔗 [Download the release](https://github.com/Hemant2000-karens/vm-downloads/releases)

⚠️ License Note: Mac OS X is proprietary software owned by Apple Inc. This release is shared for archival, educational, and testing purposes only. Please ensure you comply with applicable licensing.
